### PR TITLE
Allow updating snaps with 'UPDATE_SNAPSHOT' environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The created snapshots should be committed with your other code changes, and revi
 
 ### Updating snapshots
 
-You can update your snapshots by running your test command with a `--updateSnapshot` or `-u` flag, by deleting the snapshot file, or using the `update` option.
+You can update your snapshots by running your test command with a `--updateSnapshot` or `-u` flag, by deleting the snapshot file, specifying the "UPDATE_SNAPSHOT" environment variable, or using the `update` option.
 
 ### Expiring snapshots
 

--- a/lib/snappy-snaps.js
+++ b/lib/snappy-snaps.js
@@ -9,9 +9,13 @@ import { escapeBacktickString } from './utils.js'
 const SNAPSHOT_BANNER = '// Data Snap v1'
 const SNAPSHOT_EXT = 'snap'
 const SNAPSHOT_DIR = '__snapshots__'
+const SNAPSHOT_ENV = 'UPDATE_SNAPSHOT'
 
 const hasUpdateFlag = () => {
   const argv = process.argv.slice(2)
+  if (process.env[SNAPSHOT_ENV] !== undefined) {
+    return true
+  }
   return ['--updateSnapshot', '-u'].some((d) => argv.includes(d))
 }
 

--- a/test/snappy-snaps.spec.js
+++ b/test/snappy-snaps.spec.js
@@ -85,6 +85,26 @@ describe('lib/snappy-snaps', () => {
     process.argv.pop()
 
     assert.equal(data.name, 'Gino')
+
+    process.argv.push('--updateSnapshot')
+
+    const data2 = await subject('dog', { name: 'Gino' })
+
+    process.argv.pop()
+
+    assert.equal(data2.name, 'Gino')
+  })
+
+  it('updates snapshots when run with the update environment variable', async () => {
+    await subject('dog', { name: 'Ness' })
+
+    process.env.UPDATE_SNAPSHOT = ''
+
+    const data = await subject('dog', { name: 'Gino' })
+
+    delete process.env.UPDATE_SNAPSHOT
+
+    assert.equal(data.name, 'Gino')
   })
 
   it('warns when snapshots are past their expiry date', async () => {


### PR DESCRIPTION
Fixes #1.  I used "UPDATE_SNAPSHOT" to be parallel with the existing `--updateSnapshot`.  Test included, including adding an explicit test for `--updateSnapshot`.  Readme updated.